### PR TITLE
Add genesis agents and factory

### DIFF
--- a/packages/ai/mcpturbo_ai/__init__.py
+++ b/packages/ai/mcpturbo_ai/__init__.py
@@ -9,23 +9,40 @@ __author__ = "Federico Monfasani"
 
 # AI Agent adapters
 from .adapters import (
-    OpenAIAgent, ClaudeAgent, DeepSeekAgent,
-    create_openai_agent, create_claude_agent, create_deepseek_agent,
-    create_multi_llm_setup
+    OpenAIAgent,
+    ClaudeAgent,
+    DeepSeekAgent,
+    create_openai_agent,
+    create_claude_agent,
+    create_deepseek_agent,
+    create_multi_llm_setup,
 )
+from .genesis_agents import (
+    GenesisArchitectAgent,
+    GenesisBackendAgent,
+    GenesisFrontendAgent,
+    GenesisDevOpsAgent,
+)
+from .genesis_factory import create_genesis_agents, setup_genesis_environment
 
 # Main exports
 __all__ = [
     # Agent classes
     "OpenAIAgent",
-    "ClaudeAgent", 
+    "ClaudeAgent",
     "DeepSeekAgent",
-    
+    "GenesisArchitectAgent",
+    "GenesisBackendAgent",
+    "GenesisFrontendAgent",
+    "GenesisDevOpsAgent",
+
     # Factory functions
     "create_openai_agent",
     "create_claude_agent",
     "create_deepseek_agent",
     "create_multi_llm_setup",
+    "create_genesis_agents",
+    "setup_genesis_environment",
     
     # Metadata
     "__version__",

--- a/packages/ai/mcpturbo_ai/genesis_agents.py
+++ b/packages/ai/mcpturbo_ai/genesis_agents.py
@@ -1,0 +1,120 @@
+from typing import Dict, Any
+from mcpturbo_agents import LocalAgent, AgentCapability
+from mcpturbo_core.protocol import protocol
+
+
+class GenesisArchitectAgent(LocalAgent):
+    """Agent that designs software architecture using other LLM agents."""
+
+    def __init__(self):
+        super().__init__("genesis_architect", "Genesis Architect")
+        self.add_capability(
+            AgentCapability(
+                name="design_architecture",
+                description="Design system architecture from requirements",
+                input_schema={"requirements": {"type": "string", "required": True}},
+                output_schema={"architecture": {"type": "string"}},
+            )
+        )
+
+    async def handle_design_architecture(self, request) -> Dict[str, Any]:
+        requirements = request.data.get("requirements", "")
+        prompt = (
+            "Design a software architecture for the following requirements:\n"
+            f"{requirements}\nProvide an overview of the main components."
+        )
+        response = await protocol.send_request(
+            sender_id=self.config.agent_id,
+            target_id="claude",
+            action="reasoning",
+            data={"prompt": prompt},
+        )
+        return {"architecture": response.result.get("reasoning") or response.result.get("text", "")}
+
+
+class GenesisBackendAgent(LocalAgent):
+    """Agent that generates backend code using LLMs."""
+
+    def __init__(self):
+        super().__init__("genesis_backend", "Genesis Backend")
+        self.add_capability(
+            AgentCapability(
+                name="generate_backend",
+                description="Generate backend code from specification",
+                input_schema={
+                    "spec": {"type": "string", "required": True},
+                    "language": {"type": "string", "default": "python"},
+                },
+                output_schema={"code": {"type": "string"}},
+            )
+        )
+
+    async def handle_generate_backend(self, request) -> Dict[str, Any]:
+        spec = request.data.get("spec", "")
+        language = request.data.get("language", "python")
+        response = await protocol.send_request(
+            sender_id=self.config.agent_id,
+            target_id="openai",
+            action="code_generation",
+            data={"prompt": spec, "language": language},
+        )
+        return {"code": response.result.get("code", "")}
+
+
+class GenesisFrontendAgent(LocalAgent):
+    """Agent that generates frontend code using LLMs."""
+
+    def __init__(self):
+        super().__init__("genesis_frontend", "Genesis Frontend")
+        self.add_capability(
+            AgentCapability(
+                name="generate_frontend",
+                description="Generate frontend code from specification",
+                input_schema={
+                    "spec": {"type": "string", "required": True},
+                    "language": {"type": "string", "default": "typescript"},
+                },
+                output_schema={"code": {"type": "string"}},
+            )
+        )
+
+    async def handle_generate_frontend(self, request) -> Dict[str, Any]:
+        spec = request.data.get("spec", "")
+        language = request.data.get("language", "typescript")
+        response = await protocol.send_request(
+            sender_id=self.config.agent_id,
+            target_id="deepseek",
+            action="fast_coding",
+            data={"prompt": spec, "language": language},
+        )
+        return {"code": response.result.get("code", "")}
+
+
+class GenesisDevOpsAgent(LocalAgent):
+    """Agent that generates DevOps scripts and configuration."""
+
+    def __init__(self):
+        super().__init__("genesis_devops", "Genesis DevOps")
+        self.add_capability(
+            AgentCapability(
+                name="generate_devops",
+                description="Generate deployment or CI/CD scripts",
+                input_schema={"instructions": {"type": "string", "required": True}},
+                output_schema={"scripts": {"type": "string"}},
+            )
+        )
+
+    async def handle_generate_devops(self, request) -> Dict[str, Any]:
+        instructions = request.data.get("instructions", "")
+        prompt = (
+            "Create CI/CD or deployment scripts for the following instructions:\n"
+            f"{instructions}"
+        )
+        response = await protocol.send_request(
+            sender_id=self.config.agent_id,
+            target_id="openai",
+            action="code_generation",
+            data={"prompt": prompt, "language": "bash"},
+        )
+        return {"scripts": response.result.get("code", "")}
+

--- a/packages/ai/mcpturbo_ai/genesis_factory.py
+++ b/packages/ai/mcpturbo_ai/genesis_factory.py
@@ -1,0 +1,30 @@
+from typing import Dict
+from mcpturbo_agents import BaseAgent
+from mcpturbo_orchestrator import orchestrator
+
+from .genesis_agents import (
+    GenesisArchitectAgent,
+    GenesisBackendAgent,
+    GenesisFrontendAgent,
+    GenesisDevOpsAgent,
+)
+
+
+def create_genesis_agents() -> Dict[str, BaseAgent]:
+    """Instantiate all Genesis agents."""
+    agents = {
+        "genesis_architect": GenesisArchitectAgent(),
+        "genesis_backend": GenesisBackendAgent(),
+        "genesis_frontend": GenesisFrontendAgent(),
+        "genesis_devops": GenesisDevOpsAgent(),
+    }
+    return agents
+
+
+def setup_genesis_environment() -> Dict[str, BaseAgent]:
+    """Create and register Genesis agents with the global orchestrator."""
+    agents = create_genesis_agents()
+    for agent in agents.values():
+        orchestrator.register_agent(agent)
+    return agents
+


### PR DESCRIPTION
## Summary
- add Genesis agent implementations for architecture, backend, frontend and devops
- provide factory helpers to create/register them
- expose new helpers in `mcpturbo_ai`

## Testing
- `pytest packages/ai/tests/test_dummy.py -q`
- `pytest packages/orchestrator/tests/test_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6873002077548325852323e6720ba041