### PR TITLE
Add genesis init helpers and CLI command

### DIFF
--- a/packages/cli/mcpturbo_cli/commands/__init__.py
+++ b/packages/cli/mcpturbo_cli/commands/__init__.py
@@ -1,0 +1,5 @@
+"""Command modules for mcpturbo-cli."""
+
+from . import genesis
+
+__all__ = ["genesis"]

--- a/packages/cli/mcpturbo_cli/commands/genesis.py
+++ b/packages/cli/mcpturbo_cli/commands/genesis.py
@@ -1,0 +1,28 @@
+"""Genesis command implementations."""
+
+import argparse
+from typing import Any
+
+from ..genesis_integration import genesis_init, genesis_setup
+
+async def cmd_init(args: argparse.Namespace) -> Any:
+    """Handle `genesis init` command."""
+    return await genesis_init(args.project_name, app_type=args.type)
+
+async def cmd_setup(args: argparse.Namespace) -> Any:
+    """Handle `genesis setup` command."""
+    return await genesis_setup()
+
+
+def build_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register genesis commands with the main parser."""
+    parser = subparsers.add_parser("genesis", help="Project scaffolding commands")
+    g_sub = parser.add_subparsers(dest="genesis_command")
+
+    init_parser = g_sub.add_parser("init", help="Initialize new project")
+    init_parser.add_argument("project_name", help="Name of the project")
+    init_parser.add_argument("--type", default="web", help="Project type template")
+    init_parser.set_defaults(func=cmd_init)
+
+    setup_parser = g_sub.add_parser("setup", help="Setup orchestrator and agents")
+    setup_parser.set_defaults(func=cmd_setup)

--- a/packages/cli/mcpturbo_cli/genesis_integration.py
+++ b/packages/cli/mcpturbo_cli/genesis_integration.py
@@ -1,0 +1,44 @@
+"""Integration helpers for the `genesis` command set."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+try:  # Optional runtime dependency
+    from mcpturbo_orchestrator import orchestrator, setup_orchestrator, generate_app
+except Exception:  # pragma: no cover - orchestrator might not be installed
+    orchestrator = None  # type: ignore
+    async def setup_orchestrator(*args, **kwargs):  # type: ignore
+        raise ImportError("mcpturbo_orchestrator is required")
+
+    async def generate_app(*args, **kwargs):  # type: ignore
+        raise ImportError("mcpturbo_orchestrator is required")
+
+
+__all__ = ["genesis_init", "genesis_setup"]
+
+
+async def genesis_setup() -> Any:
+    """Setup orchestrator with agents created from environment variables."""
+    from mcpturbo_ai import create_multi_llm_setup  # Local import for optional dependency
+    openai_key = os.getenv("OPENAI_API_KEY")
+    claude_key = os.getenv("CLAUDE_API_KEY")
+    deepseek_key = os.getenv("DEEPSEEK_API_KEY")
+
+    agents: Dict[str, Any] = create_multi_llm_setup(
+        openai_key=openai_key,
+        claude_key=claude_key,
+        deepseek_key=deepseek_key,
+    )
+
+    if agents:
+        await setup_orchestrator(*agents.values())
+
+    return orchestrator
+
+
+async def genesis_init(project_name: str, app_type: str = "web", **kwargs: Any) -> Any:
+    """Initialize a new project using the orchestrator templates."""
+    await genesis_setup()
+    return await generate_app(project_name, app_type=app_type, **kwargs)

--- a/packages/cli/mcpturbo_cli/main.py
+++ b/packages/cli/mcpturbo_cli/main.py
@@ -1,12 +1,37 @@
-"""Main module for mcpturbo-cli"""
+"""Main module for mcpturbo-cli."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Optional
+
+from .commands import genesis
+
 
 class McpturboCli:
-    """Main class for mcpturbo-cli"""
-    
+    """Main entrypoint for the mcpturbo command line interface."""
+
     def __init__(self):
         self.version = "1.0.0"
-        
-    async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+
+    async def _run_async(self, args: argparse.Namespace) -> None:
+        if hasattr(args, "func"):
+            await args.func(args)
+        else:
+            raise SystemExit("No command specified")
+
+    def run(self, argv: Optional[list[str]] = None) -> None:
+        """Parse arguments and execute the chosen command."""
+        parser = argparse.ArgumentParser(prog="mcpturbo")
+        subparsers = parser.add_subparsers(dest="command")
+
+        # Register command groups
+        genesis.build_parser(subparsers)
+
+        args = parser.parse_args(argv)
+        asyncio.run(self._run_async(args))
+
+
+if __name__ == "__main__":
+    McpturboCli().run()

--- a/packages/cli/tests/test_genesis_integration.py
+++ b/packages/cli/tests/test_genesis_integration.py
@@ -1,0 +1,15 @@
+"""Tests for genesis integration helpers."""
+
+import inspect
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_genesis_helpers_exist():
+    import mcpturbo_cli.genesis_integration as gi
+
+    assert hasattr(gi, "genesis_init")
+    assert hasattr(gi, "genesis_setup")
+    assert inspect.iscoroutinefunction(gi.genesis_init)
+    assert inspect.iscoroutinefunction(gi.genesis_setup)

--- a/packages/core/mcpturbo_core/config.py
+++ b/packages/core/mcpturbo_core/config.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 from dataclasses import dataclass, field
 from pathlib import Path
 import json

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -7,6 +7,10 @@ from pathlib import Path
 # Add package to Python path
 package_dir = Path(__file__).parent.parent
 sys.path.insert(0, str(package_dir))
+# Ensure other packages in repository are importable
+repo_root = package_dir.parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "packages" / "agents"))
 
 
 @pytest.fixture

--- a/test-runner.py
+++ b/test-runner.py
@@ -1,75 +1,79 @@
 #!/usr/bin/env python3
-"""Test runner que maneja packages vacÃ­os gracefully"""
+# -*- coding: utf-8 -*-
+"""Test runner que maneja packages vacios gracefully"""
 
 import subprocess
 import sys
 from pathlib import Path
 
+
 def run_tests_for_package(package_path):
     """Run tests for a single package"""
     package_name = package_path.name
     tests_dir = package_path / "tests"
-    
+
     if not tests_dir.exists():
-        print(f"âš ï¸ No tests directory for {package_name}")
+        print(f"No tests directory for {package_name}")
         return True  # Success - no tests to run
-    
+
     test_files = list(tests_dir.glob("test_*.py"))
     if not test_files:
-        print(f"âš ï¸ No test files in {package_name}")
+        print(f"No test files in {package_name}")
         return True  # Success - no tests to run
-    
-    print(f"í·ª Running tests for {package_name}...")
-    
+
+    print(f"Running tests for {package_name}...")
+
     try:
         result = subprocess.run(
             ["python", "-m", "pytest", "tests/", "-v"],
             cwd=package_path,
             capture_output=True,
-            text=True
+            text=True,
         )
-        
+
         if result.returncode == 0:
-            print(f"âœ… {package_name} tests passed")
+            print(f"{package_name} tests passed")
             return True
         else:
-            print(f"âŒ {package_name} tests failed")
+            print(f"{package_name} tests failed")
             print(result.stdout)
             print(result.stderr)
             return False
     except Exception as e:
-        print(f"âŒ Error running tests for {package_name}: {e}")
+        print(f"Error running tests for {package_name}: {e}")
         return False
+
 
 def main():
     """Main test runner"""
     packages_dir = Path("packages")
-    
+
     if not packages_dir.exists():
-        print("âŒ No packages directory found")
+        print("No packages directory found")
         sys.exit(1)
-    
+
     packages = [d for d in packages_dir.iterdir() if d.is_dir()]
-    
-    print(f"í·ª Running tests for {len(packages)} packages...")
-    
+
+    print(f"Running tests for {len(packages)} packages...")
+
     passed = 0
     failed = 0
-    
+
     for package in packages:
         if run_tests_for_package(package):
             passed += 1
         else:
             failed += 1
-    
-    print(f"\ní³Š Test Results: {passed} passed, {failed} failed")
-    
+
+    print(f"\nTest Results: {passed} passed, {failed} failed")
+
     if failed > 0:
-        print("âŒ Some tests failed")
+        print("Some tests failed")
         sys.exit(1)
     else:
-        print("âœ… All tests passed!")
+        print("All tests passed!")
         sys.exit(0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- implement `genesis_init` and `genesis_setup` helpers
- add `genesis` command module and wire into CLI
- update tests for genesis integration
- enable imports for shared packages and fix typing import
- clean up test runner for UTF-8

## Testing
- `python test-runner.py` *(fails: coverage below threshold and protocol tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68730daceac883259d99d6d08f9a70cb