### PR TITLE
Implement entrypoint logic and tests

### DIFF
--- a/packages/ai/mcpturbo_ai/main.py
+++ b/packages/ai/mcpturbo_ai/main.py
@@ -7,6 +7,5 @@ class McpturboAi:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the AI entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/cli/mcpturbo_cli/main.py
+++ b/packages/cli/mcpturbo_cli/main.py
@@ -7,6 +7,5 @@ class McpturboCli:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the CLI entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/cli/tests/test_import.py
+++ b/packages/cli/tests/test_import.py
@@ -27,3 +27,11 @@ class TestBasicCli:
     def test_placeholder(self):
         """Placeholder test - replace with real tests"""
         assert True, "Placeholder test passed"
+
+    def test_run_executes(self):
+        """Ensure the CLI entry point runs without error"""
+        import asyncio
+        from mcpturbo_cli.main import McpturboCli
+
+        result = asyncio.run(McpturboCli().run())
+        assert "running" in result

--- a/packages/cloud-stack/mcpturbo_cloud_stack/main.py
+++ b/packages/cloud-stack/mcpturbo_cloud_stack/main.py
@@ -7,6 +7,5 @@ class McpturboCloudStack:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Cloud Stack entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/cloud/mcpturbo_cloud/main.py
+++ b/packages/cloud/mcpturbo_cloud/main.py
@@ -7,6 +7,5 @@ class McpturboCloud:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Cloud entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/complete/mcpturbo_complete/main.py
+++ b/packages/complete/mcpturbo_complete/main.py
@@ -7,6 +7,5 @@ class McpturboComplete:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Complete entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/docs/mcpturbo_docs/main.py
+++ b/packages/docs/mcpturbo_docs/main.py
@@ -7,6 +7,5 @@ class McpturboDocs:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Docs entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/enterprise/mcpturbo_enterprise/main.py
+++ b/packages/enterprise/mcpturbo_enterprise/main.py
@@ -7,6 +7,5 @@ class McpturboEnterprise:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Enterprise entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/plugins/mcpturbo_plugins/main.py
+++ b/packages/plugins/mcpturbo_plugins/main.py
@@ -7,6 +7,5 @@ class McpturboPlugins:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Plugins entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/tools/mcpturbo_tools/main.py
+++ b/packages/tools/mcpturbo_tools/main.py
@@ -7,6 +7,5 @@ class McpturboTools:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Tools entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/tools/tests/test_dummy.py
+++ b/packages/tools/tests/test_dummy.py
@@ -1,6 +1,8 @@
 """Dummy test for mcpturbo_tools"""
 
 import pytest
+import sys
+from pathlib import Path
 
 
 def test_dummy_always_pass():
@@ -10,10 +12,18 @@ def test_dummy_always_pass():
 
 def test_package_directory_exists():
     """Test that package directory exists"""
-    from pathlib import Path
     package_dir = Path(__file__).parent.parent / "mcpturbo_tools"
     # This test passes whether the directory exists or not
     assert True, "Package directory check completed"
+
+def test_run_executes():
+    """Ensure the Tools entry point runs without error"""
+    import asyncio
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from mcpturbo_tools.main import McpturboTools
+
+    result = asyncio.run(McpturboTools().run())
+    assert "running" in result
 
 
 @pytest.mark.skip(reason="Package not yet implemented")

--- a/packages/web-stack/mcpturbo_web_stack/main.py
+++ b/packages/web-stack/mcpturbo_web_stack/main.py
@@ -7,6 +7,5 @@ class McpturboWebStack:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Web Stack entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/web/mcpturbo_web/main.py
+++ b/packages/web/mcpturbo_web/main.py
@@ -7,6 +7,5 @@ class McpturboWeb:
         self.version = "1.0.0"
         
     async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+        """Run the Web entry point"""
+        return f"{self.__class__.__name__} running (v{self.version})"

--- a/packages/web/tests/test_dummy.py
+++ b/packages/web/tests/test_dummy.py
@@ -1,6 +1,8 @@
 """Dummy test for mcpturbo_web"""
 
 import pytest
+import sys
+from pathlib import Path
 
 
 def test_dummy_always_pass():
@@ -10,10 +12,18 @@ def test_dummy_always_pass():
 
 def test_package_directory_exists():
     """Test that package directory exists"""
-    from pathlib import Path
     package_dir = Path(__file__).parent.parent / "mcpturbo_web"
     # This test passes whether the directory exists or not
     assert True, "Package directory check completed"
+
+def test_run_executes():
+    """Ensure the Web entry point runs without error"""
+    import asyncio
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from mcpturbo_web.main import McpturboWeb
+
+    result = asyncio.run(McpturboWeb().run())
+    assert "running" in result
 
 
 @pytest.mark.skip(reason="Package not yet implemented")

--- a/test-runner.py
+++ b/test-runner.py
@@ -1,34 +1,36 @@
 #!/usr/bin/env python3
-"""Test runner que maneja packages vacÃ­os gracefully"""
+# -*- coding: utf-8 -*-
+"""Test runner that handles empty packages gracefully"""
 
 import subprocess
 import sys
 from pathlib import Path
 
+
 def run_tests_for_package(package_path):
     """Run tests for a single package"""
     package_name = package_path.name
     tests_dir = package_path / "tests"
-    
+
     if not tests_dir.exists():
         print(f"âš ï¸ No tests directory for {package_name}")
         return True  # Success - no tests to run
-    
+
     test_files = list(tests_dir.glob("test_*.py"))
     if not test_files:
         print(f"âš ï¸ No test files in {package_name}")
         return True  # Success - no tests to run
-    
-    print(f"í·ª Running tests for {package_name}...")
-    
+
+    print(f" Running tests for {package_name}...")
+
     try:
         result = subprocess.run(
             ["python", "-m", "pytest", "tests/", "-v"],
             cwd=package_path,
             capture_output=True,
-            text=True
+            text=True,
         )
-        
+
         if result.returncode == 0:
             print(f"âœ… {package_name} tests passed")
             return True
@@ -41,35 +43,37 @@ def run_tests_for_package(package_path):
         print(f"âŒ Error running tests for {package_name}: {e}")
         return False
 
+
 def main():
     """Main test runner"""
     packages_dir = Path("packages")
-    
+
     if not packages_dir.exists():
         print("âŒ No packages directory found")
         sys.exit(1)
-    
+
     packages = [d for d in packages_dir.iterdir() if d.is_dir()]
-    
-    print(f"í·ª Running tests for {len(packages)} packages...")
-    
+
+    print(f" Running tests for {len(packages)} packages...")
+
     passed = 0
     failed = 0
-    
+
     for package in packages:
         if run_tests_for_package(package):
             passed += 1
         else:
             failed += 1
-    
-    print(f"\ní³Š Test Results: {passed} passed, {failed} failed")
-    
+
+    print(f"\n Test Results: {passed} passed, {failed} failed")
+
     if failed > 0:
         print("âŒ Some tests failed")
         sys.exit(1)
     else:
         print("âœ… All tests passed!")
         sys.exit(0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- implement simple run() methods across packages
- ensure tests import entrypoints and run them
- fix encoding issue in test-runner

## Testing
- `pytest packages/cli/tests -q`
- `pytest packages/tools/tests -q`
- `pytest packages/web/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68730dae9824832591bcbeb42b806d2a