### PR TITLE
Add genesis init command to CLI

### DIFF
--- a/packages/cli/mcpturbo_cli/__init__.py
+++ b/packages/cli/mcpturbo_cli/__init__.py
@@ -4,8 +4,10 @@ Mcpturbo Cli
 MCPTurbo - Command Line Interface
 """
 
+from .main import McpturboCli
+
 __version__ = "1.0.0"
 __author__ = "Federico Monfasani"
 
-# Main exports will be added here
-__all__ = []
+__all__ = ["McpturboCli", "__version__", "__author__"]
+

--- a/packages/cli/mcpturbo_cli/commands/__init__.py
+++ b/packages/cli/mcpturbo_cli/commands/__init__.py
@@ -1,0 +1,4 @@
+"""Command modules for mcpturbo-cli."""
+
+__all__ = []
+

--- a/packages/cli/mcpturbo_cli/commands/genesis.py
+++ b/packages/cli/mcpturbo_cli/commands/genesis.py
@@ -1,0 +1,14 @@
+"""Commands for project initialization using Genesis."""
+
+from argparse import Namespace
+from typing import Any
+
+from ..genesis_integration import genesis_init
+
+
+async def cmd_init(args: Namespace) -> Any:
+    """Handle ``genesis init`` command."""
+    return await genesis_init(project_name=args.name, app_type=getattr(args, "type", "web"))
+
+__all__ = ["cmd_init"]
+

--- a/packages/cli/mcpturbo_cli/genesis_integration.py
+++ b/packages/cli/mcpturbo_cli/genesis_integration.py
@@ -1,0 +1,41 @@
+"""Integration helpers for the ``genesis`` project initializer."""
+
+from typing import Any, Dict
+import os
+
+from mcpturbo_core import quick_setup
+from mcpturbo_ai import create_multi_llm_setup
+from mcpturbo_orchestrator import orchestrator
+
+
+async def genesis_setup() -> Dict[str, Any]:
+    """Setup orchestrator with agents based on environment variables."""
+    # Load configuration and set environment variables via quick_setup
+    config = quick_setup()
+
+    agents = create_multi_llm_setup(
+        openai_key=config.openai_api_key,
+        claude_key=config.claude_api_key,
+        deepseek_key=config.deepseek_api_key,
+    )
+
+    for agent in agents.values():
+        orchestrator.register_agent(agent)
+
+    return {
+        "agents": list(agents.keys()),
+        "config": config,
+    }
+
+
+async def genesis_init(project_name: str, app_type: str = "web") -> Dict[str, Any]:
+    """Initialize a new project using the orchestrator workflow."""
+    await genesis_setup()
+    workflow_id = await orchestrator.create_workflow_from_template(
+        "app_generation", app_name=project_name, app_type=app_type
+    )
+    result = await orchestrator.execute_workflow(workflow_id)
+    return result
+
+__all__ = ["genesis_setup", "genesis_init"]
+

--- a/packages/cli/mcpturbo_cli/main.py
+++ b/packages/cli/mcpturbo_cli/main.py
@@ -1,12 +1,46 @@
-"""Main module for mcpturbo-cli"""
+"""Main entry point for ``mcpturbo-cli``."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Sequence
+
+from .commands import genesis as genesis_cmd
+
 
 class McpturboCli:
-    """Main class for mcpturbo-cli"""
-    
-    def __init__(self):
+    """Main class for mcpturbo-cli."""
+
+    def __init__(self) -> None:
         self.version = "1.0.0"
-        
-    async def run(self):
-        """Main execution method"""
-        # Implementation will be added
-        pass
+
+    async def run(self, argv: Sequence[str] | None = None) -> Any:
+        """Parse arguments and execute the chosen command."""
+        parser = argparse.ArgumentParser(prog="mcpturbo")
+        subparsers = parser.add_subparsers(dest="command")
+
+        # ``genesis`` command group
+        genesis_parser = subparsers.add_parser(
+            "genesis", help="Project initialization commands"
+        )
+        genesis_sub = genesis_parser.add_subparsers(dest="subcommand")
+
+        init_parser = genesis_sub.add_parser(
+            "init", help="Initialize a new project via Genesis"
+        )
+        init_parser.add_argument("name", help="Project name")
+        init_parser.add_argument(
+            "--type",
+            dest="type",
+            default="web",
+            help="Project type (default: web)",
+        )
+
+        args = parser.parse_args(list(argv) if argv is not None else None)
+
+        if args.command == "genesis" and args.subcommand == "init":
+            return await genesis_cmd.cmd_init(args)
+
+        parser.print_help()
+        return None
+


### PR DESCRIPTION
## Summary
- expose async helpers `genesis_init` and `genesis_setup`
- implement genesis command and hook up CLI
- export CLI class from package

## Testing
- `pytest packages/cli/tests/test_import.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68730e9095608325bb4440c37572d578