### PR TITLE
Implement string template rendering

### DIFF
--- a/packages/templates/mcpturbo_templates/engine.py
+++ b/packages/templates/mcpturbo_templates/engine.py
@@ -2,11 +2,17 @@
 
 class TemplateEngine:
     """Template rendering engine for code generation"""
-    
+
     def __init__(self):
         self.templates = {}
-        
+
     async def render_template(self, template_name, context):
         """Render template with given context"""
-        # Implementation will be added
-        pass
+        import string
+
+        template_content = self.templates.get(template_name)
+        if template_content is None:
+            raise KeyError(f"Template '{template_name}' not found")
+
+        template = string.Template(template_content)
+        return template.substitute(context)

--- a/packages/templates/tests/test_engine.py
+++ b/packages/templates/tests/test_engine.py
@@ -1,0 +1,9 @@
+import asyncio
+from mcpturbo_templates.engine import TemplateEngine
+
+
+def test_render_simple_template():
+    engine = TemplateEngine()
+    engine.templates["greet"] = "Hello, ${name}!"
+    result = asyncio.run(engine.render_template("greet", {"name": "World"}))
+    assert result == "Hello, World!"


### PR DESCRIPTION
## Summary
- render template contents using `string.Template`
- raise an error for missing templates
- add a test for rendering a simple template

## Testing
- `pytest -q packages/templates/tests`

------
https://chatgpt.com/codex/tasks/task_e_68730ec9ff2c8325bc34ed7b896e1bb5