### PR TITLE
Add migration and validation utilities

### DIFF
--- a/MIGRATION_REPORT.md
+++ b/MIGRATION_REPORT.md
@@ -1,0 +1,3 @@
+# Migration Report
+
+This file will be overwritten by `tools/migrate_genesis.py` when a migration is performed.

--- a/VALIDATION_REPORT.md
+++ b/VALIDATION_REPORT.md
@@ -1,0 +1,3 @@
+# Validation Report
+
+This file will be overwritten by `tools/validate_migration.py` when validation is performed.

--- a/tools/migrate_genesis.py
+++ b/tools/migrate_genesis.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+from pathlib import Path
+from datetime import datetime
+
+
+class GenesisMigrator:
+    """Copy resources from Genesis Engine into this repo."""
+
+    def __init__(self, genesis_path: str, repo_root: Path | None = None):
+        self.genesis_path = Path(genesis_path).expanduser().resolve()
+        self.repo_root = repo_root or Path(__file__).resolve().parent.parent
+        self.report_lines: list[str] = []
+
+    def _find_source(self, candidates: list[str]) -> Path | None:
+        for rel in candidates:
+            path = self.genesis_path / rel
+            if path.exists():
+                return path
+        return None
+
+    def _copy_tree(self, src: Path | None, dest: Path):
+        if not src or not src.exists():
+            self.report_lines.append(f"⚠️ Source not found: {src}")
+            return 0
+        count = 0
+        for file in src.rglob('*'):
+            if file.is_file():
+                relative = file.relative_to(src)
+                target = dest / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(file, target)
+                count += 1
+        self.report_lines.append(f"Copied {count} files from {src} to {dest}")
+        return count
+
+    def migrate(self) -> Path:
+        """Perform migration and generate report."""
+        cli_src = self._find_source([
+            'cli/commands',
+            'packages/cli/commands'
+        ])
+        templates_src = self._find_source([
+            'templates',
+            'packages/templates'
+        ])
+        workflows_src = self._find_source([
+            'workflows',
+            'packages/workflows'
+        ])
+
+        cli_dest = self.repo_root / 'packages' / 'cli' / 'commands'
+        templates_dest = self.repo_root / 'packages' / 'templates' / 'migrated'
+        workflows_dest = self.repo_root / 'packages' / 'orchestrator' / 'workflows'
+
+        cli_dest.mkdir(parents=True, exist_ok=True)
+        templates_dest.mkdir(parents=True, exist_ok=True)
+        workflows_dest.mkdir(parents=True, exist_ok=True)
+
+        self.report_lines.append(f"Migration started: {datetime.utcnow().isoformat()}\n")
+        self._copy_tree(cli_src, cli_dest)
+        self._copy_tree(templates_src, templates_dest)
+        self._copy_tree(workflows_src, workflows_dest)
+
+        report_path = self.repo_root / 'MIGRATION_REPORT.md'
+        report_content = '# Migration Report\n\n' + '\n'.join(self.report_lines)
+        report_path.write_text(report_content)
+        return report_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Migrate Genesis Engine resources')
+    parser.add_argument('genesis_path', help='Path to Genesis Engine installation')
+    parser.add_argument('--repo-root', help='Repository root', default=None)
+    args = parser.parse_args()
+
+    migrator = GenesisMigrator(args.genesis_path, Path(args.repo_root) if args.repo_root else None)
+    report = migrator.migrate()
+    print(f'Migration finished. Report generated at {report}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/validate_migration.py
+++ b/tools/validate_migration.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+from datetime import datetime
+
+
+class MigrationValidator:
+    """Validate migrated packages and agents."""
+
+    def __init__(self, repo_root: Path | None = None):
+        self.repo_root = repo_root or Path(__file__).resolve().parent.parent
+        self.report_lines: list[str] = []
+
+    def _log(self, message: str):
+        self.report_lines.append(message)
+
+    def validate_imports(self):
+        packages = [
+            "mcpturbo_cli",
+            "mcpturbo_templates",
+            "mcpturbo_generators",
+            "mcpturbo_agents",
+            "mcpturbo_core",
+            "mcpturbo_orchestrator",
+        ]
+        for pkg in packages:
+            try:
+                __import__(pkg)
+                self._log(f"✅ Imported {pkg}")
+            except Exception as exc:
+                self._log(f"❌ Failed to import {pkg}: {exc}")
+
+    def validate_agents(self):
+        try:
+            from mcpturbo_agents.base_agent import LocalAgent
+            from mcpturbo_agents.registry import AgentRegistry
+
+            agent = LocalAgent("validator", "ValidationAgent")
+            registry = AgentRegistry()
+            registry.register(agent)
+
+            if registry.get("validator"):
+                self._log("✅ Agent registry operational")
+            else:
+                self._log("❌ Agent registry failed to register agent")
+        except Exception as exc:
+            self._log(f"❌ Agent validation failed: {exc}")
+
+    def run(self) -> Path:
+        self._log(f"Validation started: {datetime.utcnow().isoformat()}\n")
+        self.validate_imports()
+        self.validate_agents()
+        report_path = self.repo_root / "VALIDATION_REPORT.md"
+        report_path.write_text("# Validation Report\n\n" + "\n".join(self.report_lines))
+        return report_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate migrated packages")
+    parser.add_argument("--repo-root", help="Repository root", default=None)
+    args = parser.parse_args()
+    validator = MigrationValidator(Path(args.repo_root) if args.repo_root else None)
+    report = validator.run()
+    print(f"Validation finished. Report generated at {report}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add tools to migrate resources from Genesis Engine
- add validation utility for migrated packages
- include initial placeholder reports

## Testing
- `python -m pytest packages -v` *(fails: Interrupted with errors)*

------
https://chatgpt.com/codex/tasks/task_e_68730dacdc548325a41ff03b3c21aff4