### PR TITLE
Use logging in cloud and complete main

### DIFF
--- a/packages/cloud/mcpturbo_cloud/main.py
+++ b/packages/cloud/mcpturbo_cloud/main.py
@@ -1,5 +1,9 @@
 """Main module for mcpturbo-cloud"""
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 class McpturboCloud:
     """Main class for mcpturbo-cloud"""
     
@@ -10,6 +14,6 @@ class McpturboCloud:
 
         """Simple execution entry point."""
         message = f"mcpturbo-cloud {self.version} running"
-        print(message)
+        logger.info(message)
         return message
 

--- a/packages/complete/mcpturbo_complete/main.py
+++ b/packages/complete/mcpturbo_complete/main.py
@@ -1,5 +1,9 @@
 """Main module for mcpturbo-complete"""
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 class McpturboComplete:
     """Main class for mcpturbo-complete"""
     
@@ -10,6 +14,6 @@ class McpturboComplete:
 
         """Simple execution entry point."""
         message = f"mcpturbo-complete {self.version} running"
-        print(message)
+        logger.info(message)
         return message
 


### PR DESCRIPTION
## Summary
- use module-level logging for cloud and complete packages
- log messages instead of printing

## Testing
- `pytest packages/cloud/tests packages/complete/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6873feb68b648325add22ad5ac0e8349