### PR TITLE
Add dev install note for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,11 @@ config.add_agent_config("openai", AgentConfig(
 ## 🧪 Testing
 
 ### Tests Unitarios
+Antes de ejecutar los tests, instala las dependencias de desarrollo:
+```bash
+pip install -e .[dev]
+```
+Estas extras incluyen librerías como `aiohttp` utilizadas en las pruebas.
 ```bash
 # Ejecutar todos los tests
 pytest packages/*/tests/


### PR DESCRIPTION
## Summary
- mention installing development extras before running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tests.test_web_stack_dummy')*

------
https://chatgpt.com/codex/tasks/task_e_6876b49dec4483258a05c381e5c49229