### PR TITLE
Improve template engine loading

### DIFF
--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -26,6 +26,24 @@ result = await component.execute()
 print(f"Result: {result}")
 ```
 
+## 📝 Template Engine
+
+The package includes a lightweight ``TemplateEngine`` class.  You can load
+templates from a directory or register them programmatically.
+
+```python
+from mcpturbo_templates.engine import TemplateEngine
+
+# Load all files inside "./templates" on creation
+engine = TemplateEngine(template_dir="./templates")
+
+# Register one template manually
+engine.register_template("greet", "Hello ${name}!")
+
+result = await engine.render_template("greet", {"name": "World"})
+print(result)  # -> "Hello World!"
+```
+
 ## 🔧 Configuration
 
 ```python

--- a/packages/templates/mcpturbo_templates/engine.py
+++ b/packages/templates/mcpturbo_templates/engine.py
@@ -1,10 +1,50 @@
-"""Template engine implementation"""
+"""Template engine implementation.
+
+The :class:`TemplateEngine` class provides a very small wrapper around
+``string.Template``.  Templates can be registered in-memory or loaded from a
+directory on disk.
+"""
+
+from pathlib import Path
 
 class TemplateEngine:
-    """Template rendering engine for code generation"""
+    """Template rendering engine for code generation."""
 
-    def __init__(self):
-        self.templates = {}
+    def __init__(self, template_dir: str | Path | None = None) -> None:
+        """Create a new engine.
+
+        Parameters
+        ----------
+        template_dir:
+            Optional directory containing template files.  The filename without
+            extension is used as the template name.  All files in the directory
+            are loaded.
+        """
+
+        self.templates: dict[str, str] = {}
+
+        if template_dir is not None:
+            self.load_templates(template_dir)
+
+    def load_templates(self, template_dir: str | Path) -> None:
+        """Load template files from ``template_dir``.
+
+        Each file in the directory is read and stored using ``Path.stem`` as the
+        template name.
+        """
+
+        directory = Path(template_dir)
+        if not directory.is_dir():
+            raise ValueError(f"{template_dir!r} is not a directory")
+
+        for file in directory.iterdir():
+            if file.is_file():
+                self.templates[file.stem] = file.read_text(encoding="utf-8")
+
+    def register_template(self, name: str, content: str) -> None:
+        """Register a template programmatically."""
+
+        self.templates[name] = content
 
     async def render_template(self, template_name, context):
         """Render template with given context"""

--- a/packages/templates/tests/test_engine.py
+++ b/packages/templates/tests/test_engine.py
@@ -7,3 +7,20 @@ def test_render_simple_template():
     engine.templates["greet"] = "Hello, ${name}!"
     result = asyncio.run(engine.render_template("greet", {"name": "World"}))
     assert result == "Hello, World!"
+
+
+def test_load_templates_from_directory(tmp_path):
+    tpl_file = tmp_path / "welcome.txt"
+    tpl_file.write_text("Welcome ${user}")
+
+    engine = TemplateEngine(template_dir=tmp_path)
+    result = asyncio.run(engine.render_template("welcome", {"user": "Alice"}))
+    assert result == "Welcome Alice"
+
+
+def test_register_template():
+    engine = TemplateEngine()
+    engine.register_template("bye", "Bye ${name}")
+
+    result = asyncio.run(engine.render_template("bye", {"name": "Bob"}))
+    assert result == "Bye Bob"


### PR DESCRIPTION
## Summary
- load templates from a directory in `TemplateEngine`
- allow dynamic registration of templates
- explain how to load and register templates in README
- test the new behaviour

## Testing
- `pytest packages/templates/tests -v`
- `python test-runner.py` *(fails: 'asyncio' not found in markers for unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_6876b49fa7708325aa6be54f89315d45