### PR TITLE
Use logging in entry points

### DIFF
--- a/packages/ai/mcpturbo_ai/main.py
+++ b/packages/ai/mcpturbo_ai/main.py
@@ -1,8 +1,16 @@
 """Main module for mcpturbo-ai"""
 
+import logging
+
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
 class McpturboAi:
     """Main class for mcpturbo-ai"""
-    
+
     def __init__(self):
         self.version = "1.0.0"
 
@@ -10,5 +18,5 @@ class McpturboAi:
 
         """Simple execution entry point."""
         message = f"mcpturbo-ai {self.version} running"
-        print(message)
+        logger.info(message)
         return message

--- a/packages/cli/mcpturbo_cli/main.py
+++ b/packages/cli/mcpturbo_cli/main.py
@@ -4,9 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from typing import Any, Sequence
 
+from mcpturbo_core.logger import configure_logging
 from .commands import genesis as genesis_cmd
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 
 
@@ -20,5 +25,5 @@ class McpturboCli:
     async def run(self):
         """Simple execution entry point."""
         message = f"mcpturbo-cli {self.version} running"
-        print(message)
+        logger.info(message)
         return message

--- a/packages/cloud-stack/mcpturbo_cloud_stack/main.py
+++ b/packages/cloud-stack/mcpturbo_cloud_stack/main.py
@@ -1,8 +1,16 @@
 """Main module for mcpturbo-cloud-stack"""
 
+import logging
+
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
 class McpturboCloudStack:
     """Main class for mcpturbo-cloud-stack"""
-    
+
     def __init__(self):
         self.version = "1.0.0"
 
@@ -10,6 +18,6 @@ class McpturboCloudStack:
 
         """Simple execution entry point."""
         message = f"mcpturbo-cloud-stack {self.version} running"
-        print(message)
+        logger.info(message)
         return message
 

--- a/packages/cloud/mcpturbo_cloud/main.py
+++ b/packages/cloud/mcpturbo_cloud/main.py
@@ -2,6 +2,9 @@
 
 import logging
 
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
 logger = logging.getLogger(__name__)
 
 class McpturboCloud:

--- a/packages/complete/mcpturbo_complete/main.py
+++ b/packages/complete/mcpturbo_complete/main.py
@@ -2,6 +2,9 @@
 
 import logging
 
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
 logger = logging.getLogger(__name__)
 
 class McpturboComplete:

--- a/packages/core/mcpturbo_core/__init__.py
+++ b/packages/core/mcpturbo_core/__init__.py
@@ -15,6 +15,7 @@ from .exceptions import (
     AgentNotFoundError, AuthenticationError, ValidationError, APIError,
     ConfigurationError, SerializationError
 )
+from .logger import configure_logging
 
 # Message types
 from .messages import (
@@ -37,6 +38,7 @@ __all__ = [
     "load_config", 
     "save_config",
     "validate_environment",
+    "configure_logging",
     
     # Message types
     "Message",

--- a/packages/core/mcpturbo_core/logger.py
+++ b/packages/core/mcpturbo_core/logger.py
@@ -1,0 +1,12 @@
+import logging
+
+
+def configure_logging(level=logging.INFO):
+    """Configure basic logging for the mcpturbo packages."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+__all__ = ["configure_logging"]

--- a/packages/docs/mcpturbo_docs/main.py
+++ b/packages/docs/mcpturbo_docs/main.py
@@ -1,8 +1,16 @@
 """Main module for mcpturbo-docs"""
 
+import logging
+
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
 class McpturboDocs:
     """Main class for mcpturbo-docs"""
-    
+
     def __init__(self):
         self.version = "1.0.0"
 
@@ -10,6 +18,6 @@ class McpturboDocs:
 
         """Simple execution entry point."""
         message = f"mcpturbo-docs {self.version} running"
-        print(message)
+        logger.info(message)
         return message
 

--- a/packages/enterprise/mcpturbo_enterprise/main.py
+++ b/packages/enterprise/mcpturbo_enterprise/main.py
@@ -1,8 +1,16 @@
 """Main module for mcpturbo-enterprise"""
 
+import logging
+
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
 class McpturboEnterprise:
     """Main class for mcpturbo-enterprise"""
-    
+
     def __init__(self):
         self.version = "1.0.0"
 
@@ -10,5 +18,5 @@ class McpturboEnterprise:
 
         """Simple execution entry point."""
         message = f"mcpturbo-enterprise {self.version} running"
-        print(message)
+        logger.info(message)
         return message

--- a/packages/plugins/mcpturbo_plugins/main.py
+++ b/packages/plugins/mcpturbo_plugins/main.py
@@ -1,8 +1,16 @@
 """Main module for mcpturbo-plugins"""
 
+import logging
+
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
 class McpturboPlugins:
     """Main class for mcpturbo-plugins"""
-    
+
     def __init__(self):
         self.version = "1.0.0"
 
@@ -10,5 +18,5 @@ class McpturboPlugins:
 
         """Simple execution entry point."""
         message = f"mcpturbo-plugins {self.version} running"
-        print(message)
+        logger.info(message)
         return message

--- a/packages/tools/mcpturbo_tools/main.py
+++ b/packages/tools/mcpturbo_tools/main.py
@@ -1,8 +1,16 @@
 """Main module for mcpturbo-tools"""
 
+import logging
+
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
 class McpturboTools:
     """Main class for mcpturbo-tools"""
-    
+
     def __init__(self):
         self.version = "1.0.0"
 
@@ -10,6 +18,6 @@ class McpturboTools:
 
         """Simple execution entry point."""
         message = f"mcpturbo-tools {self.version} running"
-        print(message)
+        logger.info(message)
         return message
 

--- a/packages/web-stack/mcpturbo_web_stack/main.py
+++ b/packages/web-stack/mcpturbo_web_stack/main.py
@@ -1,8 +1,16 @@
 """Main module for mcpturbo-web-stack"""
 
+import logging
+
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
 class McpturboWebStack:
     """Main class for mcpturbo-web-stack"""
-    
+
     def __init__(self):
         self.version = "1.0.0"
 
@@ -10,5 +18,5 @@ class McpturboWebStack:
 
         """Simple execution entry point."""
         message = f"mcpturbo-web-stack {self.version} running"
-        print(message)
+        logger.info(message)
         return message

--- a/packages/web/mcpturbo_web/main.py
+++ b/packages/web/mcpturbo_web/main.py
@@ -1,8 +1,16 @@
 """Main module for mcpturbo-web"""
 
+import logging
+
+from mcpturbo_core.logger import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
 class McpturboWeb:
     """Main class for mcpturbo-web"""
-    
+
     def __init__(self):
         self.version = "1.0.0"
 
@@ -10,6 +18,6 @@ class McpturboWeb:
 
         """Simple execution entry point."""
         message = f"mcpturbo-web {self.version} running"
-        print(message)
+        logger.info(message)
         return message
 


### PR DESCRIPTION
## Summary
- add common logger configuration
- log startup messages in all entrypoints

## Testing
- `pytest -q` *(fails: PytestUnknownMarkWarning and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876b4a0ac3c8325bae5eda8a5b5afa8