### PR TITLE
Use total_seconds for circuit breaker delay check

### DIFF
--- a/packages/core/src/mcpturbo_core/protocol.py
+++ b/packages/core/src/mcpturbo_core/protocol.py
@@ -26,7 +26,7 @@ class CircuitBreaker:
             return True
         elif self.state == CircuitState.OPEN:
             if self.last_failure_time and \
-               (datetime.utcnow() - self.last_failure_time).seconds >= self.recovery_timeout:
+               (datetime.utcnow() - self.last_failure_time).total_seconds() >= self.recovery_timeout:
                 self.state = CircuitState.HALF_OPEN
                 return True
             return False


### PR DESCRIPTION
## Summary
- fix CircuitBreaker recovery check to use `total_seconds` for proper timedelta comparison

## Testing
- `PYTHONPATH=packages/core/src:packages/agents/src pytest packages/core/tests` *(fails: Required test coverage of 80% not reached; 5 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a320e597e083259d9d7be76698e91d