### PR TITLE
feat(core): add env loader and safety limits

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Secret Management
+- Environment variables may be loaded from a local `.env` file during development.
+- **Do not store production secrets in `.env` files.** Use a secure secrets vault or key management service instead.
+- API keys and other credentials should never be committed to the repository.
+
+## Request Limits
+- Global configuration enforces `timeout` and `max_tokens` limits to prevent resource abuse.
+- Requests exceeding these limits will be rejected.
+
+## Tool Permissions
+- Tool usage is governed by configuration permissions. Disabled tools cannot be invoked.
+- Sensitive actions such as `write_file`, `delete_file`, or `execute_command` require explicit user confirmation.
+
+Please report security concerns via the repository issue tracker.

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     
     # Configuration and serialization
     "pyyaml>=6.0",
+    "python-dotenv>=1.0.0",
     
     # Enhanced error handling and retry logic
     "tenacity>=8.0.0",

--- a/packages/core/src/mcpturbo_core/messages.py
+++ b/packages/core/src/mcpturbo_core/messages.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Optional
 from datetime import datetime
 from enum import Enum
 import uuid
+from .config import get_config
 
 class MessageType(str, Enum):
     REQUEST = "request"
@@ -41,6 +42,13 @@ class Request(Message):
     action: str = ""
     timeout: int = 30
     correlation_id: Optional[str] = None
+
+    def __post_init__(self):
+        config = get_config()
+        if self.timeout > config.timeout:
+            raise ValueError(
+                f"Request timeout {self.timeout} exceeds allowed maximum {config.timeout}"
+            )
     
     def to_dict(self) -> Dict[str, Any]:
         base = super().to_dict()
@@ -98,6 +106,14 @@ class AIRequest(Request):
     temperature: float = 0.7
     max_tokens: Optional[int] = None
     system_prompt: Optional[str] = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        config = get_config()
+        if self.max_tokens and self.max_tokens > config.max_tokens:
+            raise ValueError(
+                f"Request max_tokens {self.max_tokens} exceeds allowed maximum {config.max_tokens}"
+            )
     
     def to_dict(self) -> Dict[str, Any]:
         base = super().to_dict()

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -1,0 +1,28 @@
+import pytest
+
+from mcpturbo_core.config import MCPConfig, set_config
+from mcpturbo_core.messages import Request, AIRequest
+
+
+def test_config_fields_defaults():
+    config = MCPConfig()
+    assert config.max_tokens == 2000
+    assert config.timeout == 30
+    assert config.tool_permissions == {}
+    assert "write_file" in config.sensitive_actions
+
+
+def test_request_timeout_validation():
+    config = MCPConfig(timeout=5, max_tokens=100)
+    set_config(config)
+    with pytest.raises(ValueError):
+        Request(sender="s", target="t", action="a", timeout=10)
+    set_config(MCPConfig())
+
+
+def test_request_max_tokens_validation():
+    config = MCPConfig(timeout=5, max_tokens=50)
+    set_config(config)
+    with pytest.raises(ValueError):
+        AIRequest(sender="s", target="t", action="generate", max_tokens=100)
+    set_config(MCPConfig())


### PR DESCRIPTION
## Summary
- load `.env` on startup with python-dotenv and warn about using a secrets vault
- extend `MCPConfig` with `timeout`, `max_tokens`, and tool permission fields
- validate request limits and require confirmation for sensitive actions
- document secret handling and limits in SECURITY.md

## Testing
- `pip install python-dotenv`
- `pip install pytest-cov`
- `pip install -e packages/core`
- `pip install pytest-asyncio`
- `pytest packages/core/tests -q` *(fails: circuit breaker, timeout handling, retry logic, rate limiter, coverage <80%)*

------
https://chatgpt.com/codex/tasks/task_e_68a776cbba68832580f0f4d1382e8860