### PR TITLE
Add protocol, workflow and CLI integration tests

### DIFF
--- a/packages/cli/tests/test_genesis_e2e.py
+++ b/packages/cli/tests/test_genesis_e2e.py
@@ -1,0 +1,15 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.mark.asyncio
+async def test_genesis_init_e2e():
+    import mcpturbo_cli.genesis_integration as gi
+
+    with patch("mcpturbo_cli.genesis_integration.genesis_setup", AsyncMock(return_value={})), \
+         patch.object(gi.orchestrator, "create_workflow_from_template", AsyncMock(return_value="wf1"), create=True) as mock_template, \
+         patch.object(gi.orchestrator, "execute_workflow", AsyncMock(return_value={"status": "ok"})) as mock_exec:
+        result = await gi.genesis_init("proj")
+        assert result == {"status": "ok"}
+        mock_template.assert_called_once()
+        mock_exec.assert_called_once_with("wf1")

--- a/packages/orchestrator/tests/test_workflows.py
+++ b/packages/orchestrator/tests/test_workflows.py
@@ -1,0 +1,35 @@
+import pytest
+
+from mcpturbo_orchestrator import ProjectOrchestrator, Task, Workflow, WorkflowStatus
+from mcpturbo_agents.base_agent import LocalAgent
+from mcpturbo_core.protocol import protocol
+
+
+class EchoAgent(LocalAgent):
+    def __init__(self):
+        super().__init__("echo", "Echo Agent")
+
+    async def handle_request(self, request):
+        return request.data
+
+
+@pytest.mark.asyncio
+async def test_workflow_with_dependencies():
+    """Create workflow with dependent tasks and verify execution"""
+    protocol.agents.clear()
+    orch = ProjectOrchestrator()
+    agent = EchoAgent()
+    orch.register_agent(agent)
+
+    tasks = [
+        Task(id="t1", agent_id="echo", action="echo", data={"msg": "one"}),
+        Task(id="t2", agent_id="echo", action="echo", data={"msg": "two"}, dependencies=["t1"]),
+        Task(id="t3", agent_id="echo", action="echo", data={"msg": "three"}, dependencies=["t1", "t2"]),
+    ]
+    wf = Workflow(id="wf", name="deps", tasks=tasks)
+
+    result = await orch.execute_workflow(wf)
+    assert result["status"] == WorkflowStatus.COMPLETED.value
+    task_results = {t["id"]: t["result"] for t in result["tasks"]}
+    assert task_results["t2"]["t1_result"]["msg"] == "one"
+    assert task_results["t3"]["t2_result"]["msg"] == "two"


### PR DESCRIPTION
## Summary
- extend protocol tests covering retry logic, circuit breaker failures, and external HTTP server
- add orchestrator workflow test with dependent tasks
- add CLI E2E test executing genesis_init

## Testing
- `PYTHONPATH=packages/agents/src:packages/core/src:packages/orchestrator/src:packages/ai/src:packages/cli python -m pytest packages/core/tests -q` *(fails: circuit breaker & coverage)*
- `PYTHONPATH=packages/agents/src:packages/core/src:packages/orchestrator/src:packages/ai/src:packages/cli python -m pytest packages/orchestrator/tests/test_workflows.py -q`
- `PYTHONPATH=packages/agents/src:packages/core/src:packages/orchestrator/src:packages/ai/src:packages/cli python -m pytest packages/cli/tests/test_genesis_e2e.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a776cba5b08325b2a19ce56d9ad6f7