### PR TITLE
chore: add development tooling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "mcpturbo",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "postCreateCommand": "pip install -e .[dev] && pre-commit install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker"
+      ]
+    }
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3.11
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: ["--strict"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: setup lint test bench
+
+setup:
+	pip install -e '.[dev]'
+	pre-commit install
+
+lint:
+	pre-commit run --all-files
+
+test:
+	pytest
+
+bench:
+	pytest --benchmark-only

--- a/README.md
+++ b/README.md
@@ -596,15 +596,20 @@ for agent_id in ["openai", "claude", "deepseek"]:
 git clone https://github.com/fmonfasani/mcpturbo.git
 cd mcpturbo
 
-# Instalar en modo desarrollo
-pip install -e ".[dev]"
+# Instalar dependencias y hooks
+make setup
 
-# Pre-commit hooks
-pre-commit install
+# Lint de todo el código
+make lint
 
 # Ejecutar tests
-pytest
+make test
+
+# Benchmarks opcionales
+make bench
 ```
+
+Si usas VSCode, este repositorio incluye configuración de [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) en `.devcontainer/devcontainer.json` para proporcionar un entorno con Python 3.11 y las dependencias de desarrollo preinstaladas.
 
 ### Guidelines
 1. **Código**: Seguir PEP 8, usar Black y isort


### PR DESCRIPTION
## Summary
- add pre-commit config with black, isort, ruff and mypy
- add Makefile with common development tasks
- add VS Code devcontainer setup for Python 3.11
- document make targets and devcontainer usage

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml Makefile .devcontainer/devcontainer.json` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcpturbo_core')*


------
https://chatgpt.com/codex/tasks/task_e_68a776c9b77c832598cc6a3259258902