### PR TITLE
Add basic CI workflow for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+      - name: Install dependencies
+        run: |
+          set -e
+          pip install pre-commit
+      - name: Run pre-commit
+        run: |
+          set -e
+          pre-commit run --all-files
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+      - name: Install dependencies
+        run: |
+          set -e
+          pip install pytest
+      - name: Run tests
+        run: |
+          set -e
+          pytest


### PR DESCRIPTION
## Summary
- run pre-commit and pytest in CI across Python 3.9-3.12
- cache pip dependencies to speed up runs

## Testing
- `pre-commit run --all-files` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest` *(fails: 8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a776cb8fd48325b834672dd56ff53c