### PR TITLE
feat: improve external request handling

### DIFF
--- a/packages/agents/src/mcpturbo_agents/base_agent.py
+++ b/packages/agents/src/mcpturbo_agents/base_agent.py
@@ -5,10 +5,12 @@ from datetime import datetime
 from dataclasses import dataclass
 from enum import Enum
 
+
 class AgentType(str, Enum):
     LOCAL = "local"
     EXTERNAL_API = "external_api"
     HYBRID = "hybrid"
+
 
 class AgentStatus(str, Enum):
     IDLE = "idle"
@@ -17,6 +19,7 @@ class AgentStatus(str, Enum):
     ERROR = "error"
     OFFLINE = "offline"
 
+
 @dataclass
 class AgentCapability:
     name: str
@@ -24,6 +27,7 @@ class AgentCapability:
     input_schema: Dict[str, Any]
     output_schema: Dict[str, Any]
     cost_per_request: Optional[float] = None
+
 
 @dataclass
 class AgentConfig:
@@ -34,6 +38,7 @@ class AgentConfig:
     timeout: int = 30
     retry_attempts: int = 3
     rate_limit: int = 50  # requests per minute
+
 
 class BaseAgent(ABC):
     def __init__(self, config: AgentConfig):
@@ -47,31 +52,33 @@ class BaseAgent(ABC):
             "successful_requests": 0,
             "failed_requests": 0,
             "total_execution_time": 0.0,
-            "last_activity": None
+            "last_activity": None,
         }
         self._semaphore = asyncio.Semaphore(config.max_concurrent_requests)
-        
+
         self._register_core_handlers()
-    
+
     def _register_core_handlers(self):
-        self.handlers.update({
-            "ping": self._handle_ping,
-            "status": self._handle_status,
-            "capabilities": self._handle_capabilities,
-            "stats": self._handle_stats
-        })
-    
+        self.handlers.update(
+            {
+                "ping": self._handle_ping,
+                "status": self._handle_status,
+                "capabilities": self._handle_capabilities,
+                "stats": self._handle_stats,
+            }
+        )
+
     @abstractmethod
     async def handle_request(self, request) -> Any:
         """Handle incoming request. Must be implemented by subclasses."""
         pass
-    
+
     async def execute_with_semaphore(self, request) -> Any:
         """Execute request with concurrency control"""
         async with self._semaphore:
             self.status = AgentStatus.RUNNING
             start_time = datetime.utcnow()
-            
+
             try:
                 result = await self.handle_request(request)
                 self._update_stats(True, start_time)
@@ -81,29 +88,31 @@ class BaseAgent(ABC):
                 raise e
             finally:
                 self.status = AgentStatus.IDLE
-    
+
     def _update_stats(self, success: bool, start_time: datetime):
         """Update agent statistics"""
         execution_time = (datetime.utcnow() - start_time).total_seconds()
-        
+
         self.stats["requests_handled"] += 1
         self.stats["total_execution_time"] += execution_time
         self.stats["last_activity"] = datetime.utcnow().isoformat()
-        
+
         if success:
             self.stats["successful_requests"] += 1
         else:
             self.stats["failed_requests"] += 1
-    
+
     def add_capability(self, capability: AgentCapability):
         """Add a capability to this agent"""
         self.capabilities.append(capability)
-        self.handlers[capability.name] = getattr(self, f"handle_{capability.name}", self._handle_unknown)
-    
+        self.handlers[capability.name] = getattr(
+            self, f"handle_{capability.name}", self._handle_unknown
+        )
+
     def register_handler(self, action: str, handler: Callable):
         """Register custom handler for an action"""
         self.handlers[action] = handler
-    
+
     async def _handle_ping(self, request) -> Dict[str, Any]:
         return {
             "agent_id": self.config.agent_id,
@@ -111,9 +120,9 @@ class BaseAgent(ABC):
             "status": self.status.value,
             "type": self.config.agent_type.value,
             "timestamp": datetime.utcnow().isoformat(),
-            "pong": True
+            "pong": True,
         }
-    
+
     async def _handle_status(self, request) -> Dict[str, Any]:
         return {
             "agent_id": self.config.agent_id,
@@ -122,9 +131,9 @@ class BaseAgent(ABC):
             "status": self.status.value,
             "capabilities": [cap.name for cap in self.capabilities],
             "handlers": list(self.handlers.keys()),
-            "metadata": self.metadata
+            "metadata": self.metadata,
         }
-    
+
     async def _handle_capabilities(self, request) -> Dict[str, Any]:
         return {
             "agent_id": self.config.agent_id,
@@ -134,58 +143,62 @@ class BaseAgent(ABC):
                     "description": cap.description,
                     "input_schema": cap.input_schema,
                     "output_schema": cap.output_schema,
-                    "cost_per_request": cap.cost_per_request
+                    "cost_per_request": cap.cost_per_request,
                 }
                 for cap in self.capabilities
-            ]
+            ],
         }
-    
+
     async def _handle_stats(self, request) -> Dict[str, Any]:
         avg_execution_time = 0
         if self.stats["requests_handled"] > 0:
-            avg_execution_time = self.stats["total_execution_time"] / self.stats["requests_handled"]
-        
+            avg_execution_time = (
+                self.stats["total_execution_time"] / self.stats["requests_handled"]
+            )
+
         return {
             **self.stats,
             "average_execution_time": avg_execution_time,
-            "success_rate": (self.stats["successful_requests"] / max(1, self.stats["requests_handled"])) * 100
+            "success_rate": (
+                self.stats["successful_requests"]
+                / max(1, self.stats["requests_handled"])
+            )
+            * 100,
         }
-    
+
     async def _handle_unknown(self, request) -> Dict[str, Any]:
         return {
             "error": f"Unknown action: {getattr(request, 'action', 'unknown')}",
-            "available_actions": list(self.handlers.keys())
+            "available_actions": list(self.handlers.keys()),
         }
+
 
 class LocalAgent(BaseAgent):
     """Agent that runs locally in the same process"""
-    
+
     def __init__(self, agent_id: str, name: str, **kwargs):
         config = AgentConfig(
-            agent_id=agent_id,
-            name=name,
-            agent_type=AgentType.LOCAL,
-            **kwargs
+            agent_id=agent_id, name=name, agent_type=AgentType.LOCAL, **kwargs
         )
         super().__init__(config)
-    
+
     async def handle_request(self, request) -> Any:
-        action = getattr(request, 'action', 'unknown')
+        action = getattr(request, "action", "unknown")
         handler = self.handlers.get(action, self._handle_unknown)
-        
+
         if asyncio.iscoroutinefunction(handler):
             return await handler(request)
         return handler(request)
 
+
 class ExternalAgent(BaseAgent):
     """Agent that communicates with external API"""
-    
-    def __init__(self, agent_id: str, name: str, api_url: str, api_key: str = None, **kwargs):
+
+    def __init__(
+        self, agent_id: str, name: str, api_url: str, api_key: str = None, **kwargs
+    ):
         config = AgentConfig(
-            agent_id=agent_id,
-            name=name,
-            agent_type=AgentType.EXTERNAL_API,
-            **kwargs
+            agent_id=agent_id, name=name, agent_type=AgentType.EXTERNAL_API, **kwargs
         )
         super().__init__(config)
         self.api_url = api_url
@@ -193,70 +206,76 @@ class ExternalAgent(BaseAgent):
         self.headers = {"Content-Type": "application/json"}
         if api_key:
             self.headers["Authorization"] = f"Bearer {api_key}"
-    
+
     async def handle_request(self, request) -> Any:
         """Handle request by calling external API"""
-        from mcpturbo_core.protocol import protocol
-        return await protocol._send_external_request(self, request)
-    
+        from mcpturbo_core.protocol import protocol, send_external_request
+
+        if not protocol.session:
+            await protocol.start()
+        return await send_external_request(protocol.session, self, request)
+
     def build_payload(self, request) -> Dict[str, Any]:
         """Build API payload. Override in subclasses for specific APIs"""
         return {
-            "action": getattr(request, 'action', ''),
-            "data": getattr(request, 'data', {})
+            "action": getattr(request, "action", ""),
+            "data": getattr(request, "data", {}),
         }
+
 
 class HybridAgent(BaseAgent):
     """Agent that can work both locally and with external APIs"""
-    
+
     def __init__(self, agent_id: str, name: str, **kwargs):
         config = AgentConfig(
-            agent_id=agent_id,
-            name=name,
-            agent_type=AgentType.HYBRID,
-            **kwargs
+            agent_id=agent_id, name=name, agent_type=AgentType.HYBRID, **kwargs
         )
         super().__init__(config)
         self.local_handlers: Dict[str, Callable] = {}
         self.external_endpoints: Dict[str, str] = {}
-    
+
     def register_local_handler(self, action: str, handler: Callable):
         """Register handler for local execution"""
         self.local_handlers[action] = handler
-    
+
     def register_external_endpoint(self, action: str, endpoint: str):
         """Register endpoint for external API calls"""
         self.external_endpoints[action] = endpoint
-    
+
     async def handle_request(self, request) -> Any:
-        action = getattr(request, 'action', '')
-        
+        action = getattr(request, "action", "")
+
         # Try local handler first
         if action in self.local_handlers:
             handler = self.local_handlers[action]
             if asyncio.iscoroutinefunction(handler):
                 return await handler(request)
             return handler(request)
-        
+
         # Fall back to external API
         if action in self.external_endpoints:
             # Use external API logic
             return await self._call_external_api(action, request)
-        
+
         # Default handler
         return await self._handle_unknown(request)
-    
+
     async def _call_external_api(self, action: str, request) -> Any:
         """Call external API for specific action"""
         # Implementation would depend on specific API
         raise NotImplementedError("External API call not implemented")
 
+
 # Utility functions
+
 
 def create_local_agent(agent_id: str, name: str = None, **kwargs) -> LocalAgent:
     """Create a simple local agent"""
     return LocalAgent(agent_id, name or agent_id.replace("_", " ").title(), **kwargs)
 
-def create_external_agent(agent_id: str, name: str, api_url: str, api_key: str = None, **kwargs) -> ExternalAgent:
+
+def create_external_agent(
+    agent_id: str, name: str, api_url: str, api_key: str = None, **kwargs
+) -> ExternalAgent:
     """Create an external API agent"""
     return ExternalAgent(agent_id, name, api_url, api_key, **kwargs)

--- a/packages/core/src/mcpturbo_core/__init__.py
+++ b/packages/core/src/mcpturbo_core/__init__.py
@@ -8,58 +8,76 @@ __version__ = "2.0.0"
 __author__ = "Federico Monfasani"
 
 # Core protocol and configuration
-from .protocol import MCPProtocol, protocol
-from .config import MCPConfig, get_config, load_config, save_config, validate_environment
+from .protocol import MCPProtocol, protocol, send_external_request
+from .config import (
+    MCPConfig,
+    get_config,
+    load_config,
+    save_config,
+    validate_environment,
+)
 from .exceptions import (
-    MCPError, TimeoutError, RateLimitError, CircuitBreakerError,
-    AgentNotFoundError, AuthenticationError, ValidationError, APIError,
-    ConfigurationError, SerializationError
+    MCPError,
+    TimeoutError,
+    RateLimitError,
+    CircuitBreakerError,
+    AgentNotFoundError,
+    AuthenticationError,
+    ValidationError,
+    APIError,
+    ConfigurationError,
+    SerializationError,
 )
 from .logger import configure_logging
 
 # Message types
 from .messages import (
-    Message, Request, Response, Event, AIRequest, AIResponse,
-    MessageType, Priority,
-    create_request, create_ai_request, create_response, create_event
+    Message,
+    Request,
+    Response,
+    Event,
+    AIRequest,
+    AIResponse,
+    MessageType,
+    Priority,
+    create_request,
+    create_ai_request,
+    create_response,
+    create_event,
 )
 
 # Main exports
 __all__ = [
     # Core classes
     "MCPProtocol",
-    "MCPConfig", 
-    
+    "MCPConfig",
     # Global instances
     "protocol",
-    
+    "send_external_request",
     # Configuration functions
     "get_config",
-    "load_config", 
+    "load_config",
     "save_config",
     "validate_environment",
     "configure_logging",
-    
     # Message types
     "Message",
     "Request",
-    "Response", 
+    "Response",
     "Event",
     "AIRequest",
     "AIResponse",
     "MessageType",
     "Priority",
-    
     # Message factories
     "create_request",
     "create_ai_request",
     "create_response",
     "create_event",
-    
     # Exceptions
     "MCPError",
     "TimeoutError",
-    "RateLimitError", 
+    "RateLimitError",
     "CircuitBreakerError",
     "AgentNotFoundError",
     "AuthenticationError",
@@ -67,36 +85,40 @@ __all__ = [
     "APIError",
     "ConfigurationError",
     "SerializationError",
-    
     # Metadata
     "__version__",
-    "__author__"
+    "__author__",
 ]
+
 
 # Initialize global protocol
 async def initialize():
     """Initialize MCPturbo core components"""
     await protocol.start()
 
+
 async def cleanup():
     """Cleanup MCPturbo core components"""
     await protocol.stop()
 
+
 # Quick setup function
-def quick_setup(openai_key: str = None, claude_key: str = None, deepseek_key: str = None) -> MCPConfig:
+def quick_setup(
+    openai_key: str = None, claude_key: str = None, deepseek_key: str = None
+) -> MCPConfig:
     """
     Quick setup for MCPturbo with API keys
-    
+
     Args:
         openai_key: OpenAI API key
-        claude_key: Claude API key  
+        claude_key: Claude API key
         deepseek_key: DeepSeek API key
-        
+
     Returns:
         Configured MCPConfig instance
     """
     import os
-    
+
     # Set environment variables if provided
     if openai_key:
         os.environ["OPENAI_API_KEY"] = openai_key
@@ -104,13 +126,13 @@ def quick_setup(openai_key: str = None, claude_key: str = None, deepseek_key: st
         os.environ["CLAUDE_API_KEY"] = claude_key
     if deepseek_key:
         os.environ["DEEPSEEK_API_KEY"] = deepseek_key
-    
+
     # Load configuration
     config = load_config()
-    
+
     # Validate setup
     validation = validate_environment()
     if not validation["valid"]:
         raise MCPError(f"Setup validation failed: {validation['issues']}")
-    
+
     return config

--- a/packages/core/src/mcpturbo_core/protocol.py
+++ b/packages/core/src/mcpturbo_core/protocol.py
@@ -1,17 +1,28 @@
 import asyncio
+import json
 import aiohttp
 import time
-from typing import Dict, List, Optional, Any, Callable
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Union
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from .messages import Request, Response, Event
-from .exceptions import MCPError, TimeoutError, RateLimitError, CircuitBreakerError
+
+from tenacity import (
+    AsyncRetrying,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception,
+)
+
+from .messages import Event, Request, Response
+from .exceptions import MCPError, RateLimitError, TimeoutError, CircuitBreakerError
+
 
 class CircuitState(Enum):
     CLOSED = "closed"
-    OPEN = "open" 
+    OPEN = "open"
     HALF_OPEN = "half_open"
+
 
 @dataclass
 class CircuitBreaker:
@@ -20,45 +31,53 @@ class CircuitBreaker:
     state: CircuitState = CircuitState.CLOSED
     failure_count: int = 0
     last_failure_time: Optional[datetime] = None
-    
+
     def should_allow_request(self) -> bool:
         if self.state == CircuitState.CLOSED:
             return True
         elif self.state == CircuitState.OPEN:
-            if self.last_failure_time and \
-               (datetime.utcnow() - self.last_failure_time).total_seconds() >= self.recovery_timeout:
+            if (
+                self.last_failure_time
+                and (datetime.utcnow() - self.last_failure_time).total_seconds()
+                >= self.recovery_timeout
+            ):
                 self.state = CircuitState.HALF_OPEN
                 return True
             return False
         return True
-    
+
     def record_success(self):
         self.failure_count = 0
         self.state = CircuitState.CLOSED
         self.last_failure_time = None
-    
+
     def record_failure(self):
         self.failure_count += 1
         self.last_failure_time = datetime.utcnow()
         if self.failure_count >= self.failure_threshold:
             self.state = CircuitState.OPEN
 
+
 @dataclass
 class RateLimiter:
     requests_per_minute: int = 50
     tokens: float = 50
     last_refill: float = field(default_factory=time.time)
-    
+
     def can_proceed(self) -> bool:
         now = time.time()
         time_passed = now - self.last_refill
-        self.tokens = min(self.requests_per_minute, self.tokens + (time_passed * self.requests_per_minute / 60))
+        self.tokens = min(
+            self.requests_per_minute,
+            self.tokens + (time_passed * self.requests_per_minute / 60),
+        )
         self.last_refill = now
-        
+
         if self.tokens >= 1:
             self.tokens -= 1
             return True
         return False
+
 
 @dataclass
 class RetryConfig:
@@ -66,6 +85,106 @@ class RetryConfig:
     initial_delay: float = 1.0
     max_delay: float = 30.0
     exponential_base: float = 2.0
+
+
+ALLOWED_PAYLOAD_FIELDS = {"action", "data"}
+MAX_PAYLOAD_SIZE = 10000
+
+
+def sanitize_payload(
+    payload: Dict[str, Any],
+    allowed_fields: Optional[set] = None,
+    max_size: int = MAX_PAYLOAD_SIZE,
+) -> Dict[str, Any]:
+    allowed = allowed_fields or ALLOWED_PAYLOAD_FIELDS
+    sanitized = {k: v for k, v in payload.items() if k in allowed}
+    serialized = json.dumps(sanitized)
+    if len(serialized.encode("utf-8")) > max_size:
+        raise MCPError("Payload exceeds maximum size")
+    return sanitized
+
+
+def handle_api_error(status: int, text: str) -> None:
+    if 400 <= status < 500:
+        raise MCPError(f"Client error {status}: {text}")
+    elif status >= 500:
+        raise MCPError(f"Server error {status}: {text}")
+    else:
+        raise MCPError(f"Unexpected error {status}: {text}")
+
+
+async def send_external_request(
+    session: aiohttp.ClientSession,
+    agent: Any,
+    request: Request,
+    *,
+    stream: bool = False,
+) -> Union[Any, AsyncGenerator[str, None]]:
+    if hasattr(agent, "build_payload"):
+        payload = agent.build_payload(request)
+    else:
+        payload = {"action": request.action, "data": request.data}
+    payload = sanitize_payload(payload)
+
+    headers: Dict[str, str] = {}
+    if hasattr(agent, "api_key"):
+        headers["Authorization"] = f"Bearer {agent.api_key}"
+    if hasattr(agent, "headers"):
+        headers.update(agent.headers)
+
+    async def _request_json() -> Any:
+        async with session.post(
+            agent.api_url,
+            json=payload,
+            headers=headers,
+            timeout=request.timeout,
+        ) as response:
+            if response.status >= 400:
+                text = await response.text()
+                handle_api_error(response.status, text)
+            return await response.json()
+
+    async def _request_stream() -> AsyncGenerator[str, None]:
+        async with session.post(
+            agent.api_url,
+            json=payload,
+            headers=headers,
+            timeout=request.timeout,
+        ) as response:
+            if response.status >= 400:
+                text = await response.text()
+                handle_api_error(response.status, text)
+            async for chunk in response.content.iter_any():
+                yield chunk.decode()
+
+    retry_policy = retry_if_exception(
+        lambda e: isinstance(e, MCPError) and "Server error" in str(e)
+    )
+
+    if stream:
+
+        async def _stream() -> AsyncGenerator[str, None]:
+            async for attempt in AsyncRetrying(
+                wait=wait_exponential(),
+                stop=stop_after_attempt(3),
+                retry=retry_policy,
+                reraise=True,
+            ):
+                with attempt:
+                    async for chunk in _request_stream():
+                        yield chunk
+
+        return _stream()
+    else:
+        async for attempt in AsyncRetrying(
+            wait=wait_exponential(),
+            stop=stop_after_attempt(3),
+            retry=retry_policy,
+            reraise=True,
+        ):
+            with attempt:
+                return await _request_json()
+
 
 class MCPProtocol:
     def __init__(self):
@@ -78,122 +197,137 @@ class MCPProtocol:
         self.running = False
         self.messages_sent = 0
         self.messages_received = 0
-        
+
     async def start(self):
         if not self.running:
             self.session = aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=60),
-                connector=aiohttp.TCPConnector(limit=100)
+                connector=aiohttp.TCPConnector(limit=100),
             )
             self.running = True
-    
+
     async def stop(self):
         if self.running:
             if self.session:
                 await self.session.close()
             self.running = False
-    
+
     def register_agent(self, agent_id: str, agent: Any, **config):
         self.agents[agent_id] = agent
-        
+
         # Configurar circuit breaker
         self.circuit_breakers[agent_id] = CircuitBreaker(
-            failure_threshold=config.get('failure_threshold', 5),
-            recovery_timeout=config.get('recovery_timeout', 60)
+            failure_threshold=config.get("failure_threshold", 5),
+            recovery_timeout=config.get("recovery_timeout", 60),
         )
-        
+
         # Configurar rate limiter
         self.rate_limiters[agent_id] = RateLimiter(
-            requests_per_minute=config.get('rate_limit', 50)
+            requests_per_minute=config.get("rate_limit", 50)
         )
-    
+
     def subscribe(self, event: str, handler: Callable):
         if event not in self.event_handlers:
             self.event_handlers[event] = []
         self.event_handlers[event].append(handler)
-    
-    async def send_request(self, sender_id: str, target_id: str, action: str, 
-                          data: Dict[str, Any] = None, timeout: int = 30,
-                          retry_config: Optional[RetryConfig] = None) -> Response:
-        
+
+    async def send_request(
+        self,
+        sender_id: str,
+        target_id: str,
+        action: str,
+        data: Dict[str, Any] = None,
+        timeout: int = 30,
+        retry_config: Optional[RetryConfig] = None,
+        stream: bool = False,
+    ) -> Response:
+
         if not self.running:
             await self.start()
-        
+
         # Verificar circuit breaker
         circuit_breaker = self.circuit_breakers.get(target_id)
         if circuit_breaker and not circuit_breaker.should_allow_request():
             raise CircuitBreakerError(f"Circuit breaker open for {target_id}")
-        
+
         # Verificar rate limit
         rate_limiter = self.rate_limiters.get(target_id)
         if rate_limiter and not rate_limiter.can_proceed():
             raise RateLimitError(f"Rate limit exceeded for {target_id}")
-        
+
         request = Request(
             sender=sender_id,
             target=target_id,
             action=action,
             data=data or {},
-            timeout=timeout
+            timeout=timeout,
         )
-        
+
         retry_config = retry_config or RetryConfig()
         last_error = None
-        
+
         for attempt in range(retry_config.max_attempts):
             try:
                 self.messages_sent += 1
-                response = await self._send_request_attempt(request)
-                
+                response = await self._send_request_attempt(request, stream)
+
                 # Actualizar circuit breaker en éxito
                 if circuit_breaker:
                     circuit_breaker.record_success()
-                
+
                 return response
-                
+
             except Exception as e:
                 last_error = e
-                
+
                 # Actualizar circuit breaker en fallo
                 if circuit_breaker:
                     circuit_breaker.record_failure()
-                
+
                 if attempt < retry_config.max_attempts - 1:
                     delay = min(
-                        retry_config.initial_delay * (retry_config.exponential_base ** attempt),
-                        retry_config.max_delay
+                        retry_config.initial_delay
+                        * (retry_config.exponential_base**attempt),
+                        retry_config.max_delay,
                     )
                     await asyncio.sleep(delay)
                     continue
                 break
-        
+
         raise last_error or MCPError("Request failed after all retries")
-    
-    async def _send_request_attempt(self, request: Request) -> Response:
+
+    async def _send_request_attempt(
+        self, request: Request, stream: bool = False
+    ) -> Response:
         agent = self.agents.get(request.target)
         if not agent:
             raise MCPError(f"Agent {request.target} not found")
-        
+
         try:
-            if hasattr(agent, 'handle_request'):
+            if hasattr(agent, "api_url"):
+                # Agente externo (API)
+                if not self.session:
+                    await self.start()
+                send_result = send_external_request(
+                    self.session, agent, request, stream=stream
+                )
+                result = send_result if stream else await send_result
+            elif hasattr(agent, "handle_request"):
                 # Agente local
                 result = await agent.handle_request(request)
-            elif hasattr(agent, 'api_url'):
-                # Agente externo (API)
-                result = await self._send_external_request(agent, request)
             else:
                 raise MCPError(f"Agent {request.target} not compatible")
-            
+
             response = Response(
                 sender=request.target,
                 target=request.sender,
                 request_id=request.id,
                 success=True,
-                result=result
+                result=result,
             )
             self.messages_received += 1
             return response
-            
+
         except asyncio.TimeoutError:
             raise TimeoutError(f"Request to {request.target} timed out")
         except Exception as e:
@@ -202,48 +336,16 @@ class MCPProtocol:
                 target=request.sender,
                 request_id=request.id,
                 success=False,
-                error=str(e)
+                error=str(e),
             )
             self.messages_received += 1
             return response
-    
-    async def _send_external_request(self, agent: Any, request: Request) -> Any:
-        if not self.session:
-            await self.start()
-        
-        # Construir payload según el tipo de agente
-        if hasattr(agent, 'build_payload'):
-            payload = agent.build_payload(request)
-        else:
-            payload = {
-                "action": request.action,
-                "data": request.data
-            }
-        
-        headers = {}
-        if hasattr(agent, 'api_key'):
-            headers['Authorization'] = f"Bearer {agent.api_key}"
-        if hasattr(agent, 'headers'):
-            headers.update(agent.headers)
-        
-        async with self.session.post(
-            agent.api_url,
-            json=payload,
-            headers=headers,
-            timeout=request.timeout
-        ) as response:
-            if response.status >= 400:
-                raise MCPError(f"API error {response.status}: {await response.text()}")
-            
-            return await response.json()
-    
-    async def broadcast_event(self, sender_id: str, event: str, data: Dict[str, Any] = None):
-        event_msg = Event(
-            sender=sender_id,
-            event=event,
-            data=data or {}
-        )
-        
+
+    async def broadcast_event(
+        self, sender_id: str, event: str, data: Dict[str, Any] = None
+    ):
+        event_msg = Event(sender=sender_id, event=event, data=data or {})
+
         handlers = self.event_handlers.get(event, [])
         for handler in handlers:
             try:
@@ -253,7 +355,7 @@ class MCPProtocol:
                     handler(event_msg)
             except Exception:
                 continue
-    
+
     def get_stats(self) -> Dict[str, Any]:
         return {
             "agents": len(self.agents),
@@ -261,20 +363,15 @@ class MCPProtocol:
             "messages_sent": self.messages_sent,
             "messages_received": self.messages_received,
             "circuit_breakers": {
-                agent_id: {
-                    "state": cb.state.value,
-                    "failure_count": cb.failure_count
-                }
+                agent_id: {"state": cb.state.value, "failure_count": cb.failure_count}
                 for agent_id, cb in self.circuit_breakers.items()
             },
             "rate_limits": {
-                agent_id: {
-                    "tokens": rl.tokens,
-                    "limit": rl.requests_per_minute
-                }
+                agent_id: {"tokens": rl.tokens, "limit": rl.requests_per_minute}
                 for agent_id, rl in self.rate_limiters.items()
-            }
+            },
         }
+
 
 # Instancia global
 protocol = MCPProtocol()

--- a/packages/core/tests/test_external_request.py
+++ b/packages/core/tests/test_external_request.py
@@ -1,0 +1,52 @@
+import aiohttp
+import pytest
+from unittest.mock import patch
+
+from mcpturbo_core.messages import Request
+from mcpturbo_core.protocol import send_external_request
+
+pytestmark = pytest.mark.asyncio
+
+
+class DummyAgent:
+    api_url = "https://api.example.com"
+    api_key = "test"
+
+
+class MockResponse:
+    def __init__(self, status: int, json_data=None, text_data="error"):
+        self.status = status
+        self._json = json_data or {}
+        self._text = text_data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self._json
+
+    async def text(self):
+        return self._text
+
+
+async def test_send_external_request_retries_on_500():
+    agent = DummyAgent()
+    request = Request(sender="s", target="t", action="a")
+
+    responses = [
+        MockResponse(500),
+        MockResponse(500),
+        MockResponse(200, json_data={"ok": True}),
+    ]
+
+    def mock_post(*args, **kwargs):
+        return responses.pop(0)
+
+    async with aiohttp.ClientSession() as session:
+        with patch.object(session, "post", side_effect=mock_post) as post:
+            result = await send_external_request(session, agent, request)
+            assert result == {"ok": True}
+            assert post.call_count == 3


### PR DESCRIPTION
## Summary
- expose `send_external_request` with payload sanitization, error classification and exponential retries
- support streaming responses and retry logic in protocol and external agents
- add regression test for retrying on server errors

## Testing
- `PYTHONPATH=packages/core/src:packages/agents/src pytest packages/core/tests/test_external_request.py packages/core/tests/test_protocol.py::TestMCPProtocol::test_external_api_request packages/core/tests/test_protocol.py::TestMCPProtocol::test_external_api_error_handling --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68a776c66cc08325bf1a4fc97ae7c6d0