### PR TITLE
Add workflow template builders and template-based orchestration

### DIFF
--- a/packages/orchestrator/pyproject.toml
+++ b/packages/orchestrator/pyproject.toml
@@ -81,6 +81,9 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = [
     "--strict-markers",
-    "--strict-config", 
+    "--strict-config",
     "--verbose",
+]
+markers = [
+    "asyncio: mark test as running with asyncio",
 ]

--- a/packages/orchestrator/src/mcpturbo_orchestrator/__init__.py
+++ b/packages/orchestrator/src/mcpturbo_orchestrator/__init__.py
@@ -9,9 +9,10 @@ __author__ = "Federico Monfasani"
 
 # Core orchestration classes
 from .orchestrator import (
-    ProjectOrchestrator, Workflow, Task, 
+    ProjectOrchestrator, Workflow, Task,
     WorkflowStatus, TaskPriority, orchestrator
 )
+from .workflow_templates import TEMPLATE_BUILDERS
 
 # Main exports
 __all__ = [
@@ -33,10 +34,10 @@ __all__ = [
 ]
 
 # Convenience functions
-async def quick_workflow(template_name: str, **kwargs) -> str:
+async def quick_workflow(template_name: str, **kwargs) -> dict:
     """Create and execute workflow from template"""
-    workflow_id = await orchestrator.create_workflow_from_template(template_name, **kwargs)
-    result = await orchestrator.execute_workflow(workflow_id)
+    workflow = orchestrator.create_workflow_from_template(template_name, **kwargs)
+    result = await orchestrator.execute_workflow(workflow)
     return result
 
 async def generate_app(app_name: str, app_type: str = "web", **kwargs) -> dict:
@@ -52,16 +53,12 @@ async def design_architecture(requirements: str, **kwargs) -> dict:
     return await quick_workflow("architecture_design", requirements=requirements, **kwargs)
 
 # Workflow templates available
-AVAILABLE_TEMPLATES = [
-    "app_generation",
-    "code_review", 
-    "architecture_design"
-]
+AVAILABLE_TEMPLATES = list(TEMPLATE_BUILDERS.keys())
 
 # Setup function for orchestrator
 async def setup_orchestrator(*agents, **config):
     """Setup orchestrator with agents"""
     for agent in agents:
         orchestrator.register_agent(agent, **config)
-    
+
     return orchestrator

--- a/packages/orchestrator/src/mcpturbo_orchestrator/orchestrator.py
+++ b/packages/orchestrator/src/mcpturbo_orchestrator/orchestrator.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from .workflow_model import Workflow
 from .task_model import Task
 from .workflow_state import WorkflowStatus, TaskPriority
+from .workflow_templates import TEMPLATE_BUILDERS
 from mcpturbo_core.protocol import protocol
 from mcpturbo_core.exceptions import MCPError
 from mcpturbo_agents import BaseAgent
@@ -22,6 +23,30 @@ class ProjectOrchestrator:
 
     def subscribe_to_events(self, event: str, handler: Callable):
         self.event_handlers.setdefault(event, []).append(handler)
+
+    def create_workflow_from_template(self, name: str, **kwargs) -> Workflow:
+        """Instantiate a workflow from a named template.
+
+        Parameters
+        ----------
+        name:
+            Template identifier present in :data:`TEMPLATE_BUILDERS`.
+        **kwargs:
+            Parameters forwarded to the template builder.
+
+        Returns
+        -------
+        Workflow
+            The newly created workflow, also registered in ``self.workflows``.
+        """
+
+        builder = TEMPLATE_BUILDERS.get(name)
+        if builder is None:
+            raise ValueError(f"Unknown workflow template: {name}")
+
+        workflow = builder(**kwargs)
+        self.workflows[workflow.id] = workflow
+        return workflow
 
     async def execute_workflow(self, workflow: Workflow) -> Dict[str, Any]:
         self.workflows[workflow.id] = workflow

--- a/packages/orchestrator/src/mcpturbo_orchestrator/workflow_templates.py
+++ b/packages/orchestrator/src/mcpturbo_orchestrator/workflow_templates.py
@@ -1,11 +1,83 @@
-# Aquí irán tus plantillas de workflows predefinidos:
-# _create_app_generation_workflow
-# _create_code_review_workflow
-# _create_architecture_workflow
+"""Predefined workflow templates and builders."""
 
-# Cada una devuelve un objeto `Workflow` con tareas preconfiguradas.
+from __future__ import annotations
 
-# Ejemplo de firma esperada:
-# def _create_app_generation_workflow(**kwargs) -> Workflow:
-#     ...
-#     return Workflow(id=..., name=..., tasks=[...])
+from typing import Callable, Dict, Any
+
+from .workflow_model import Workflow
+from .task_model import Task
+
+
+def _create_app_generation_workflow(
+    *,
+    agent_id: str,
+    data: Dict[str, Any] | None = None,
+    workflow_id: str = "app_generation",
+    name: str = "App Generation",
+    **kwargs: Any,
+) -> Workflow:
+    """Build a simple app generation workflow.
+
+    Parameters
+    ----------
+    agent_id:
+        The agent responsible for handling the task.
+    data:
+        Optional payload forwarded to the agent.
+    workflow_id / name:
+        Optional identifiers for the resulting workflow.
+    """
+
+    task = Task(
+        id="generate_app",
+        agent_id=agent_id,
+        action="generate_app",
+        data=data or {},
+    )
+    return Workflow(id=workflow_id, name=name, tasks=[task])
+
+
+def _create_code_review_workflow(
+    *,
+    agent_id: str,
+    code: str = "",
+    workflow_id: str = "code_review",
+    name: str = "Code Review",
+    **kwargs: Any,
+) -> Workflow:
+    """Build a workflow that performs a code review."""
+
+    task = Task(
+        id="review_code",
+        agent_id=agent_id,
+        action="review_code",
+        data={"code": code},
+    )
+    return Workflow(id=workflow_id, name=name, tasks=[task])
+
+
+def _create_architecture_workflow(
+    *,
+    agent_id: str,
+    requirements: str = "",
+    workflow_id: str = "architecture_design",
+    name: str = "Architecture Design",
+    **kwargs: Any,
+) -> Workflow:
+    """Build an architecture design workflow."""
+
+    task = Task(
+        id="design_architecture",
+        agent_id=agent_id,
+        action="design_architecture",
+        data={"requirements": requirements},
+    )
+    return Workflow(id=workflow_id, name=name, tasks=[task])
+
+
+TEMPLATE_BUILDERS: Dict[str, Callable[..., Workflow]] = {
+    "app_generation": _create_app_generation_workflow,
+    "code_review": _create_code_review_workflow,
+    "architecture_design": _create_architecture_workflow,
+}
+

--- a/packages/orchestrator/tests/test_workflow_templates.py
+++ b/packages/orchestrator/tests/test_workflow_templates.py
@@ -1,0 +1,44 @@
+import pytest
+
+from mcpturbo_orchestrator import ProjectOrchestrator, WorkflowStatus
+from mcpturbo_agents.base_agent import LocalAgent
+
+
+class EchoAgent(LocalAgent):
+    def __init__(self):
+        super().__init__("template", "Template Agent")
+
+    async def handle_request(self, request):
+        return request.data
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "template_name, action",
+    [
+        ("app_generation", "generate_app"),
+        ("code_review", "review_code"),
+        ("architecture_design", "design_architecture"),
+    ],
+)
+async def test_template_builders_execute(template_name, action):
+    orchestrator = ProjectOrchestrator()
+    agent = EchoAgent()
+    orchestrator.register_agent(agent)
+
+    workflow = orchestrator.create_workflow_from_template(
+        template_name, agent_id=agent.config.agent_id
+    )
+
+    assert workflow.id in orchestrator.workflows
+
+    result = await orchestrator.execute_workflow(workflow)
+    assert result["status"] == WorkflowStatus.COMPLETED.value
+    assert result["tasks"][0]["action"] == action
+
+
+def test_unknown_template_raises():
+    orchestrator = ProjectOrchestrator()
+    with pytest.raises(ValueError):
+        orchestrator.create_workflow_from_template("unknown")
+


### PR DESCRIPTION
## Summary
- add predefined workflow builders and expose TEMPLATE_BUILDERS
- support creating workflows from templates in ProjectOrchestrator
- update convenience functions and template list
- test workflow templates and register asyncio marker

## Testing
- `pytest packages/orchestrator/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a776c73cd48325b842fc32af59d273