### PR TITLE
feat: add shared types package and TS declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,28 @@ async def main():
 asyncio.run(main())
 ```
 
+## 📘 Tipos Compartidos y Clientes TypeScript
+
+El paquete `mcpturbo-shared-types` expone modelos Pydantic y archivos `.d.ts`
+equivalentes para que los clientes escritos en TypeScript puedan reutilizar los
+mismos tipos.
+
+```bash
+pip install mcpturbo-shared-types
+```
+
+Luego, desde un proyecto TypeScript, importa las interfaces:
+
+```ts
+import type { Message, Workflow } from "mcpturbo-shared-types/types";
+
+const message: Message = {
+  id: "1",
+  role: "user",
+  content: "hola",
+};
+```
+
 ## 🛠️ Uso como librería
 
 El protocolo y el orquestador se exponen también como clases para que puedas

--- a/packages/shared-types/README.md
+++ b/packages/shared-types/README.md
@@ -1,0 +1,3 @@
+# mcpturbo-shared-types
+
+Shared Pydantic models and corresponding TypeScript declarations for MCPturbo.

--- a/packages/shared-types/pyproject.toml
+++ b/packages/shared-types/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mcpturbo-shared-types"
+version = "1.0.0"
+description = "Shared Pydantic models and TypeScript types for MCPturbo"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "Federico Monfasani", email = "fmonfasani@gmail.com"}
+]
+keywords = ["mcpturbo", "types", "pydantic", "typescript"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Intended Audience :: Developers",
+]
+requires-python = ">=3.9"
+dependencies = [
+    "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = ["datamodel-code-generator>=0.25.0"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["mcpturbo_shared_types*"]

--- a/packages/shared-types/src/mcpturbo_shared_types/__init__.py
+++ b/packages/shared-types/src/mcpturbo_shared_types/__init__.py
@@ -1,0 +1,5 @@
+"""Shared Pydantic models for MCPturbo."""
+
+from .models import Message, Task, Workflow
+
+__all__ = ["Message", "Task", "Workflow"]

--- a/packages/shared-types/src/mcpturbo_shared_types/models.py
+++ b/packages/shared-types/src/mcpturbo_shared_types/models.py
@@ -1,0 +1,42 @@
+"""Pydantic models shared across MCPturbo packages."""
+
+from __future__ import annotations
+
+from typing import List
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+class Message(BaseModel):
+    """Represents a message exchanged between actors."""
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    role: str
+    content: str
+
+    def to_dict(self) -> dict:
+        """Return a serialisable dictionary representation of the message."""
+        return self.model_dump()
+
+
+class Task(BaseModel):
+    """A unit of work consisting of multiple messages."""
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    messages: List[Message] = []
+
+    def to_dict(self) -> dict:
+        """Return a serialisable dictionary representation of the task."""
+        return self.model_dump()
+
+
+class Workflow(BaseModel):
+    """A workflow composed of ordered tasks."""
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    tasks: List[Task] = []
+
+    def to_dict(self) -> dict:
+        """Return a serialisable dictionary representation of the workflow."""
+        return self.model_dump()

--- a/packages/shared-types/tests/conftest.py
+++ b/packages/shared-types/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Add package src directory to Python path for tests
+package_dir = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(package_dir))

--- a/packages/shared-types/tests/test_models.py
+++ b/packages/shared-types/tests/test_models.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from mcpturbo_shared_types import Message, Task, Workflow
+
+
+def test_serialization_roundtrip():
+    msg = Message(role="user", content="hi")
+    task = Task(messages=[msg])
+    wf = Workflow(tasks=[task])
+
+    data = wf.to_dict()
+    assert data["tasks"][0]["messages"][0]["content"] == "hi"
+
+
+def test_type_declaration_files_exist():
+    types_dir = Path(__file__).resolve().parent.parent / "types"
+    assert (types_dir / "message.d.ts").exists()
+    assert (types_dir / "workflow.d.ts").exists()

--- a/packages/shared-types/types/message.d.ts
+++ b/packages/shared-types/types/message.d.ts
@@ -1,0 +1,5 @@
+export interface Message {
+  id: string;
+  role: string;
+  content: string;
+}

--- a/packages/shared-types/types/workflow.d.ts
+++ b/packages/shared-types/types/workflow.d.ts
@@ -1,0 +1,11 @@
+import { Message } from './message';
+
+export interface Task {
+  id: string;
+  messages: Message[];
+}
+
+export interface Workflow {
+  id: string;
+  tasks: Task[];
+}

--- a/scripts/generate-ts-types.py
+++ b/scripts/generate-ts-types.py
@@ -1,0 +1,42 @@
+"""Generate TypeScript declaration files from Pydantic models."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from mcpturbo_shared_types import Message, Workflow
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent / "packages" / "shared-types"
+TYPES_DIR = PACKAGE_ROOT / "types"
+MODELS = [("message", Message), ("workflow", Workflow)]
+
+
+def generate_ts() -> None:
+    TYPES_DIR.mkdir(parents=True, exist_ok=True)
+    for name, model in MODELS:
+        schema = model.model_json_schema()
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
+            json.dump(schema, tmp)
+            tmp_path = Path(tmp.name)
+        subprocess.run(
+            [
+                "datamodel-codegen",
+                "--input",
+                str(tmp_path),
+                "--input-file-type",
+                "jsonschema",
+                "--output",
+                str(TYPES_DIR / f"{name}.d.ts"),
+                "--target",
+                "typescript",
+            ],
+            check=True,
+        )
+        tmp_path.unlink()
+
+
+if __name__ == "__main__":
+    generate_ts()


### PR DESCRIPTION
## Summary
- add `mcpturbo-shared-types` package with Pydantic models
- provide TypeScript declaration files and generation script
- document using shared types from TypeScript clients

## Testing
- `pytest packages/shared-types/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a776c8e62083258e8dc976f9c24262